### PR TITLE
Add WebGUI template with Vue.js and Golang

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+# Use the official Go image as the base image
+FROM golang:1.16
+
+# Install Node.js and npm
+RUN apt-get update && apt-get install -y \
+    curl \
+    && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+    && apt-get install -y nodejs
+
+# Set the working directory for the backend
+WORKDIR /workspace/backend
+
+# Copy the backend files
+COPY backend/go.mod backend/go.sum ./
+RUN go mod download
+COPY backend/ .
+
+# Set the working directory for the frontend
+WORKDIR /workspace/frontend
+
+# Copy the frontend files
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm install
+COPY frontend/ .
+
+# Expose the ports for the backend and frontend
+EXPOSE 8080 8081
+
+# Set the default working directory
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "ssl_gui_test",
+  "dockerFile": "Dockerfile",
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+  "extensions": [
+    "ms-vscode.go",
+    "octref.vetur"
+  ],
+  "postCreateCommand": "npm install",
+  "remoteUser": "vscode"
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
 # ssl_gui_test
+
+## Setup and Startup
+
+### Frontend (Vue.js)
+
+1. Navigate to the `frontend` directory:
+   ```bash
+   cd frontend
+   ```
+
+2. Install the dependencies:
+   ```bash
+   npm install
+   ```
+
+3. Start the development server:
+   ```bash
+   npm run serve
+   ```
+
+### Backend (Golang)
+
+1. Navigate to the `backend` directory:
+   ```bash
+   cd backend
+   ```
+
+2. Install the dependencies:
+   ```bash
+   go mod tidy
+   ```
+
+3. Start the backend server:
+   ```bash
+   go run main.go
+   ```
+
+### Usage
+
+1. Open your browser and navigate to `http://localhost:8080`.
+2. You should see a canvas where shapes will be drawn based on the data received from the backend.
+3. The backend will forward UDP packets to the frontend via WebSocket, and the shapes will be drawn on the canvas accordingly.
+
+## Developing with Devcontainer
+
+1. Open the repository in Visual Studio Code.
+2. Install the "Remote - Containers" extension if you haven't already.
+3. Press `F1` and select `Remote-Containers: Open Folder in Container...`.
+4. Select the root folder of the repository.
+5. The development container will be built and started automatically.
+6. You can now develop the project inside the container.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,7 @@
+module backend
+
+go 1.16
+
+require (
+	github.com/gorilla/websocket v1.4.2
+)

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
+
+var clients = make(map[*websocket.Conn]bool)
+var broadcast = make(chan []byte)
+
+func main() {
+	http.HandleFunc("/ws", handleConnections)
+	go handleUDP()
+	go handleMessages()
+	fmt.Println("Server started on :8080")
+	err := http.ListenAndServe(":8080", nil)
+	if err != nil {
+		fmt.Println("Error starting server:", err)
+	}
+}
+
+func handleConnections(w http.ResponseWriter, r *http.Request) {
+	ws, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		fmt.Println("Error upgrading connection:", err)
+		return
+	}
+	defer ws.Close()
+
+	clients[ws] = true
+
+	for {
+		_, msg, err := ws.ReadMessage()
+		if err != nil {
+			fmt.Println("Error reading message:", err)
+			delete(clients, ws)
+			break
+		}
+		fmt.Println("Received message:", string(msg))
+	}
+}
+
+func handleUDP() {
+	addr := net.UDPAddr{
+		Port: 8081,
+		IP:   net.ParseIP("0.0.0.0"),
+	}
+	conn, err := net.ListenUDP("udp", &addr)
+	if err != nil {
+		fmt.Println("Error starting UDP server:", err)
+		return
+	}
+	defer conn.Close()
+
+	buf := make([]byte, 1024)
+	for {
+		n, _, err := conn.ReadFromUDP(buf)
+		if err != nil {
+			fmt.Println("Error reading UDP packet:", err)
+			continue
+		}
+		fmt.Println("Received UDP packet:", string(buf[:n]))
+		broadcast <- buf[:n]
+	}
+}
+
+func handleMessages() {
+	for {
+		msg := <-broadcast
+		for client := range clients {
+			err := client.WriteMessage(websocket.TextMessage, msg)
+			if err != nil {
+				fmt.Println("Error writing message:", err)
+				client.Close()
+				delete(clients, client)
+			}
+		}
+	}
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ssl_gui_test",
+  "version": "1.0.0",
+  "description": "A WebGUI template created with Vue.js for the frontend and Golang for the backend.",
+  "main": "src/main.js",
+  "scripts": {
+    "serve": "vue-cli-service serve",
+    "build": "vue-cli-service build"
+  },
+  "dependencies": {
+    "vue": "^3.0.0"
+  },
+  "devDependencies": {
+    "@vue/cli-service": "^4.5.0"
+  },
+  "author": "",
+  "license": "Apache-2.0"
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,75 @@
+<template>
+  <div id="app">
+    <canvas id="canvas" width="800" height="600"></canvas>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'App',
+  data() {
+    return {
+      shapes: []
+    };
+  },
+  methods: {
+    drawShapes() {
+      const canvas = this.$refs.canvas;
+      const ctx = canvas.getContext('2d');
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      this.shapes.forEach(shape => {
+        switch (shape.type) {
+          case 'circle':
+            this.drawCircle(ctx, shape);
+            break;
+          case 'line':
+            this.drawLine(ctx, shape);
+            break;
+          case 'rectangle':
+            this.drawRectangle(ctx, shape);
+            break;
+          case 'text':
+            this.drawText(ctx, shape);
+            break;
+        }
+      });
+    },
+    drawCircle(ctx, shape) {
+      ctx.beginPath();
+      ctx.arc(shape.x, shape.y, shape.radius, 0, 2 * Math.PI);
+      ctx.fillStyle = shape.color;
+      ctx.fill();
+    },
+    drawLine(ctx, shape) {
+      ctx.beginPath();
+      ctx.moveTo(shape.x1, shape.y1);
+      ctx.lineTo(shape.x2, shape.y2);
+      ctx.strokeStyle = shape.color;
+      ctx.stroke();
+    },
+    drawRectangle(ctx, shape) {
+      ctx.fillStyle = shape.color;
+      ctx.fillRect(shape.x, shape.y, shape.width, shape.height);
+    },
+    drawText(ctx, shape) {
+      ctx.font = shape.font;
+      ctx.fillStyle = shape.color;
+      ctx.fillText(shape.text, shape.x, shape.y);
+    }
+  },
+  mounted() {
+    const canvas = this.$refs.canvas;
+    const ctx = canvas.getContext('2d');
+    this.drawShapes();
+  },
+  watch: {
+    shapes: 'drawShapes'
+  }
+};
+</script>
+
+<style>
+#canvas {
+  border: 1px solid black;
+}
+</style>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,12 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+const app = createApp(App);
+
+const ws = new WebSocket('ws://localhost:8080');
+ws.onmessage = (event) => {
+  const shapes = JSON.parse(event.data);
+  app.config.globalProperties.$shapes = shapes;
+};
+
+app.mount('#app');


### PR DESCRIPTION
Fixes #1

Add WebGUI template with Vue.js for frontend and Golang for backend.

* **Frontend:**
  - Add `frontend/package.json` to manage dependencies.
  - Add `frontend/src/App.vue` with canvas element and methods to draw shapes.
  - Add `frontend/src/main.js` to initialize Vue.js app and set up WebSocket connection.

* **Backend:**
  - Add `backend/go.mod` to manage dependencies.
  - Add `backend/main.go` to handle UDP packets and WebSocket connections.

* **Documentation:**
  - Update `README.md` with setup and startup instructions, and explanation on developing with devcontainer.

* **Devcontainer:**
  - Add `.devcontainer/devcontainer.json` to configure the development container.
  - Add `.devcontainer/Dockerfile` to define the development container image.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HansRobo/ssl_gui_test/issues/1?shareId=335a5775-35a4-41d9-a079-55b46d52efed).