### PR TITLE
Add code comments in Japanese

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,52 @@
 # ssl_gui_test
 
-## Setup and Startup
+## セットアップと起動
 
-### Frontend (Vue.js)
+### フロントエンド (Vue.js)
 
-1. Navigate to the `frontend` directory:
+1. `frontend`ディレクトリに移動します:
    ```bash
    cd frontend
    ```
 
-2. Install the dependencies:
+2. 依存関係をインストールします:
    ```bash
    npm install
    ```
 
-3. Start the development server:
+3. 開発サーバーを起動します:
    ```bash
    npm run serve
    ```
 
-### Backend (Golang)
+### バックエンド (Golang)
 
-1. Navigate to the `backend` directory:
+1. `backend`ディレクトリに移動します:
    ```bash
    cd backend
    ```
 
-2. Install the dependencies:
+2. 依存関係をインストールします:
    ```bash
    go mod tidy
    ```
 
-3. Start the backend server:
+3. バックエンドサーバーを起動します:
    ```bash
    go run main.go
    ```
 
-### Usage
+### 使用方法
 
-1. Open your browser and navigate to `http://localhost:8080`.
-2. You should see a canvas where shapes will be drawn based on the data received from the backend.
-3. The backend will forward UDP packets to the frontend via WebSocket, and the shapes will be drawn on the canvas accordingly.
+1. ブラウザを開き、`http://localhost:8080`にアクセスします。
+2. キャンバスが表示され、バックエンドから受信したデータに基づいて図形が描画されます。
+3. バックエンドはUDPパケットをWebSocket経由でフロントエンドに転送し、キャンバス上に図形が描画されます。
 
-## Developing with Devcontainer
+## Devcontainerを使用した開発
 
-1. Open the repository in Visual Studio Code.
-2. Install the "Remote - Containers" extension if you haven't already.
-3. Press `F1` and select `Remote-Containers: Open Folder in Container...`.
-4. Select the root folder of the repository.
-5. The development container will be built and started automatically.
-6. You can now develop the project inside the container.
+1. Visual Studio Codeでリポジトリを開きます。
+2. まだインストールしていない場合は、「Remote - Containers」拡張機能をインストールします。
+3. `F1`キーを押して、`Remote-Containers: Open Folder in Container...`を選択します。
+4. リポジトリのルートフォルダを選択します。
+5. 開発コンテナが自動的にビルドされ、起動します。
+6. コンテナ内でプロジェクトの開発を行うことができます。

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,5 +3,6 @@ module backend
 go 1.16
 
 require (
+	// requireセクションは、プロジェクトが依存するパッケージを定義します。
 	github.com/gorilla/websocket v1.4.2
 )

--- a/backend/main.go
+++ b/backend/main.go
@@ -17,6 +17,7 @@ var upgrader = websocket.Upgrader{
 var clients = make(map[*websocket.Conn]bool)
 var broadcast = make(chan []byte)
 
+// メイン関数は、WebSocketサーバーを起動し、UDPパケットを処理するための関数をゴルーチンとして実行します。
 func main() {
 	http.HandleFunc("/ws", handleConnections)
 	go handleUDP()
@@ -28,6 +29,7 @@ func main() {
 	}
 }
 
+// handleConnections関数は、WebSocket接続を処理し、クライアントからのメッセージを受信します。
 func handleConnections(w http.ResponseWriter, r *http.Request) {
 	ws, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
@@ -49,6 +51,7 @@ func handleConnections(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// handleUDP関数は、UDPサーバーを起動し、受信したUDPパケットをブロードキャストチャネルに送信します。
 func handleUDP() {
 	addr := net.UDPAddr{
 		Port: 8081,
@@ -73,6 +76,7 @@ func handleUDP() {
 	}
 }
 
+// handleMessages関数は、ブロードキャストチャネルからメッセージを受信し、すべてのクライアントに送信します。
 func handleMessages() {
 	for {
 		msg := <-broadcast

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,13 +4,16 @@
   "description": "A WebGUI template created with Vue.js for the frontend and Golang for the backend.",
   "main": "src/main.js",
   "scripts": {
+    // scriptsセクションは、プロジェクトのビルドやサーバーの起動などのコマンドを定義します。
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build"
   },
   "dependencies": {
+    // dependenciesセクションは、プロジェクトが依存するパッケージを定義します。
     "vue": "^3.0.0"
   },
   "devDependencies": {
+    // devDependenciesセクションは、開発環境でのみ使用されるパッケージを定義します。
     "@vue/cli-service": "^4.5.0"
   },
   "author": "",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,6 +13,7 @@ export default {
     };
   },
   methods: {
+    // drawShapesメソッドは、キャンバス上に図形を描画します。
     drawShapes() {
       const canvas = this.$refs.canvas;
       const ctx = canvas.getContext('2d');
@@ -34,12 +35,14 @@ export default {
         }
       });
     },
+    // drawCircleメソッドは、キャンバス上に円を描画します。
     drawCircle(ctx, shape) {
       ctx.beginPath();
       ctx.arc(shape.x, shape.y, shape.radius, 0, 2 * Math.PI);
       ctx.fillStyle = shape.color;
       ctx.fill();
     },
+    // drawLineメソッドは、キャンバス上に線を描画します。
     drawLine(ctx, shape) {
       ctx.beginPath();
       ctx.moveTo(shape.x1, shape.y1);
@@ -47,10 +50,12 @@ export default {
       ctx.strokeStyle = shape.color;
       ctx.stroke();
     },
+    // drawRectangleメソッドは、キャンバス上に長方形を描画します。
     drawRectangle(ctx, shape) {
       ctx.fillStyle = shape.color;
       ctx.fillRect(shape.x, shape.y, shape.width, shape.height);
     },
+    // drawTextメソッドは、キャンバス上にテキストを描画します。
     drawText(ctx, shape) {
       ctx.font = shape.font;
       ctx.fillStyle = shape.color;

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,7 +3,10 @@ import App from './App.vue';
 
 const app = createApp(App);
 
+// WebSocket接続を確立します。
 const ws = new WebSocket('ws://localhost:8080');
+
+// WebSocketのonmessageイベントハンドラを設定します。
 ws.onmessage = (event) => {
   const shapes = JSON.parse(event.data);
   app.config.globalProperties.$shapes = shapes;


### PR DESCRIPTION
Fixes #3

Add code comments in Japanese to various files in the project.

* **backend/main.go**
  - Add comments to explain the purpose of the `main`, `handleConnections`, `handleUDP`, and `handleMessages` functions.

* **frontend/src/App.vue**
  - Add comments to explain the purpose of the `drawShapes`, `drawCircle`, `drawLine`, `drawRectangle`, and `drawText` methods.

* **frontend/src/main.js**
  - Add comments to explain the purpose of the WebSocket connection and the `onmessage` event handler.

* **frontend/package.json**
  - Add comments to explain the purpose of the `scripts`, `dependencies`, and `devDependencies` sections.

* **backend/go.mod**
  - Add comments to explain the purpose of the `require` section.

* **README.md**
  - Translate the setup and startup instructions for the frontend and backend into Japanese.
  - Translate the usage instructions into Japanese.
  - Translate the instructions for developing with Devcontainer into Japanese.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HansRobo/ssl_gui_test/issues/3?shareId=ceca809d-2abf-41b5-9b3c-4646a2fc4dcc).