### PR TITLE
Add .gitignore to ignore cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+*.log
+*.cache
+dist/
+build/


### PR DESCRIPTION
Fixes #5

Add a `.gitignore` file to prevent cache files from being committed.

* Add `node_modules/` to ignore Node.js dependencies
* Add `*.log` to ignore log files
* Add `*.cache` to ignore cache files
* Add `dist/` to ignore distribution files
* Add `build/` to ignore build files

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HansRobo/ssl_gui_test/issues/5?shareId=57798867-21b7-4452-aed1-71e63c2604ea).