### PR TITLE
Add linters and pre-commit hooks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run ESLint
+        run: npm run lint

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@
    npm run serve
    ```
 
+4. ESLintを使用してコードをチェックします:
+   ```bash
+   npm run lint
+   ```
+
 ### バックエンド (Golang)
 
 1. `backend`ディレクトリに移動します:
@@ -36,6 +41,11 @@
    go run main.go
    ```
 
+4. GolangCI-Lintを使用してコードをチェックします:
+   ```bash
+   golangci-lint run
+   ```
+
 ### 使用方法
 
 1. ブラウザを開き、`http://localhost:8080`にアクセスします。
@@ -50,3 +60,54 @@
 4. リポジトリのルートフォルダを選択します。
 5. 開発コンテナが自動的にビルドされ、起動します。
 6. コンテナ内でプロジェクトの開発を行うことができます。
+
+## Pre-commitフックの設定
+
+1. `frontend`ディレクトリに移動します:
+   ```bash
+   cd frontend
+   ```
+
+2. Huskyをインストールします:
+   ```bash
+   npx husky install
+   ```
+
+3. Pre-commitフックを設定します:
+   ```bash
+   npx husky add .husky/pre-commit "npm run lint"
+   ```
+
+## GitHub ActionsによるLintingワークフロー
+
+1. `.github/workflows/lint.yml`ファイルを作成し、以下の内容を追加します:
+   ```yaml
+   name: Lint
+
+   on:
+     push:
+       branches:
+         - main
+     pull_request:
+       branches:
+         - main
+
+   jobs:
+     lint:
+       runs-on: ubuntu-latest
+
+       steps:
+         - name: Checkout code
+           uses: actions/checkout@v2
+
+         - name: Set up Node.js
+           uses: actions/setup-node@v2
+           with:
+             node-version: '14'
+
+         - name: Install dependencies
+           run: npm install
+
+         - name: Run ESLint
+           run: npm run lint
+   ```

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,0 +1,24 @@
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - deadcode
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+
+linters-settings:
+  errcheck:
+    exclude:
+      - "fmt:.*"
+  govet:
+    check-shadowing: true
+  staticcheck:
+    checks: ["all"]

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,0 +1,22 @@
+module.exports = {
+  extends: [
+    'plugin:vue/vue3-essential',
+    'eslint:recommended'
+  ],
+  env: {
+    browser: true,
+    node: true
+  },
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module'
+  },
+  rules: {
+    'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    'vue/no-unused-vars': 'warn',
+    'vue/no-multiple-template-root': 'off',
+    'vue/require-default-prop': 'off',
+    'vue/require-prop-types': 'off'
+  }
+};

--- a/frontend/.huskyrc
+++ b/frontend/.huskyrc
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "pre-commit": "npm run lint"
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,17 +4,23 @@
   "description": "A WebGUI template created with Vue.js for the frontend and Golang for the backend.",
   "main": "src/main.js",
   "scripts": {
-    // scriptsセクションは、プロジェクトのビルドやサーバーの起動などのコマンドを定義します。
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build"
+    "build": "vue-cli-service build",
+    "lint": "eslint . --ext .js,.vue"
   },
   "dependencies": {
-    // dependenciesセクションは、プロジェクトが依存するパッケージを定義します。
     "vue": "^3.0.0"
   },
   "devDependencies": {
-    // devDependenciesセクションは、開発環境でのみ使用されるパッケージを定義します。
-    "@vue/cli-service": "^4.5.0"
+    "@vue/cli-service": "^4.5.0",
+    "eslint": "^7.32.0",
+    "eslint-plugin-vue": "^7.0.0",
+    "husky": "^7.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run lint"
+    }
   },
   "author": "",
   "license": "Apache-2.0"


### PR DESCRIPTION
Fixes #7

Add linting configuration and setup for pre-commit hooks and GitHub Actions.

* **Frontend Linting Configuration:**
  - Add `frontend/.eslintrc.js` for ESLint configuration.
  - Modify `frontend/package.json` to include `eslint`, `eslint-plugin-vue`, and `husky` in `devDependencies`.
  - Add `lint` script in `frontend/package.json`.
  - Add Husky configuration in `frontend/package.json` and `frontend/.huskyrc` for pre-commit hook to run ESLint.

* **GitHub Actions Workflow:**
  - Add `.github/workflows/lint.yml` to run ESLint on push and pull request events.
  - Use `actions/checkout@v4` and `actions/setup-node@v2`.

* **Backend Linting Configuration:**
  - Add `backend/.golangci.yml` for GolangCI-Lint configuration.

* **Documentation:**
  - Update `README.md` with instructions for using ESLint, GolangCI-Lint, setting up pre-commit hooks with Husky, and GitHub Actions linting workflow.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HansRobo/ssl_gui_test/issues/7?shareId=eef272ca-8744-441d-9928-025e60c34e85).