### PR TITLE
Fix linter workflow error partially

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: '14'
 
       - name: Install dependencies
-        run: npm install
+        run: cd frontend && npm install
 
       - name: Run ESLint
-        run: npm run lint
+        run: cd frontend && npm run lint


### PR DESCRIPTION
Fixes #9

Update linter workflow to fix missing `package.json` error.

* **Install dependencies**
  - Change `npm install` command to `cd frontend && npm install` to point to the correct directory.
* **Run ESLint**
  - Change `npm run lint` command to `cd frontend && npm run lint` to point to the correct directory.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HansRobo/ssl_gui_test/issues/9?shareId=6b27789d-5e36-4829-b4c3-850c03313f8e).