### PR TITLE
Receive SSL_WrapperPacket and send primitives to frontend

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -8,8 +8,35 @@ const ws = new WebSocket('ws://localhost:8080');
 
 // WebSocketのonmessageイベントハンドラを設定します。
 ws.onmessage = (event) => {
-  const shapes = JSON.parse(event.data);
-  app.config.globalProperties.$shapes = shapes;
+  const data = event.data.split(',');
+  const type = data[0];
+  let shape = null;
+
+  if (type === 'line') {
+    shape = {
+      type: 'line',
+      x1: parseFloat(data[1]),
+      y1: parseFloat(data[2]),
+      x2: parseFloat(data[3]),
+      y2: parseFloat(data[4]),
+      color: 'black'
+    };
+  } else if (type === 'circle') {
+    shape = {
+      type: 'circle',
+      x: parseFloat(data[1]),
+      y: parseFloat(data[2]),
+      radius: parseFloat(data[3]),
+      color: 'black'
+    };
+  }
+
+  if (shape) {
+    if (!app.config.globalProperties.$shapes) {
+      app.config.globalProperties.$shapes = [];
+    }
+    app.config.globalProperties.$shapes.push(shape);
+  }
 };
 
 app.mount('#app');

--- a/proto/ssl_vision_wrapper.proto
+++ b/proto/ssl_vision_wrapper.proto
@@ -4,8 +4,10 @@ option go_package = "github.com/RoboCup-SSL/ssl-vision-client/pkg/vision";
 
 import "ssl_vision_detection.proto";
 import "ssl_vision_geometry.proto";
+import "ssl_visualization.proto";
 
 message SSL_WrapperPacket {
   optional SSL_DetectionFrame detection = 1;
   optional SSL_GeometryData geometry = 2;
+  optional VisualizationFrame visualization = 3;
 }


### PR DESCRIPTION
Fixes #14

Update `backend/main.go` to handle `SSL_WrapperPacket` from `224.5.23.2:10006` and send primitives to the frontend.

* **Backend Changes:**
  - Update `handleUDP` to listen on `224.5.23.2:10006`.
  - Add `handleSSLWrapperPacket` function to process `SSL_WrapperPacket` and extract primitives.
  - Update `handleUDP` to call `handleSSLWrapperPacket` and send primitives to the `broadcast` channel.

* **Frontend Changes:**
  - Update `ws.onmessage` in `frontend/src/main.js` to handle primitives from `SSL_WrapperPacket`.
  - Add logic to draw shapes based on received primitives.

* **Proto Changes:**
  - Add `import "ssl_visualization.proto";` to `proto/ssl_vision_wrapper.proto`.
  - Add `optional VisualizationFrame visualization = 3;` to `SSL_WrapperPacket`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HansRobo/ssl_gui_test/issues/14?shareId=382d974c-51bc-4d7f-88af-f9924d1d5088).